### PR TITLE
linked-events.swagger fixes and addition

### DIFF
--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -732,6 +732,9 @@ definitions:
       publisher:
         type: string
         description: Organization responsible for this event record.
+      accessible:
+        type: boolean
+        description: Is event accessible for everyone
   offer:
     title: Price offers
     description: information record for this event. The prices are not in a structured format and the format depends on information source. An exception to this is the case of free event. These are indicated using is_free flag, which is searchable.

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -732,9 +732,6 @@ definitions:
       publisher:
         type: string
         description: Organization responsible for this event record.
-      accessible:
-        type: boolean
-        description: Is event accessible for everyone
   offer:
     title: Price offers
     description: information record for this event. The prices are not in a structured format and the format depends on information source. An exception to this is the case of free event. These are indicated using is_free flag, which is searchable.

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -486,8 +486,17 @@ definitions:
         type: string
         description: Unique identifier for this keyword_set. These should be URIs identifying the source and the keyword_set itself, and preferably also well formed http-URLs pointing to more information about the keyword.
       name:
-        type: string
-        description: Name for this keyword_set. This should be human readable, such that it could be shown as label in UI
+        type: object
+        properties:
+          fi:
+            type: string
+            description: Keyword in Finnish
+          sv:
+            type: string
+            description: Keyword in Swedish
+          en:
+            type: string
+            description: Keyword in English
       origin_id:
         type: string
         description: "Set identifier in the originating system, if any"
@@ -1118,7 +1127,7 @@ paths:
             type: object
             properties:
               meta:
-                $ref: "#/definitions/keyword"
+                $ref: "#/definitions/meta_definition"
               data:
                 type: array
                 items:

--- a/linked-events.swagger.yaml
+++ b/linked-events.swagger.yaml
@@ -490,13 +490,13 @@ definitions:
         properties:
           fi:
             type: string
-            description: Keyword in Finnish
+            description: Keyword set name in Finnish
           sv:
             type: string
-            description: Keyword in Swedish
+            description: Keyword set name in Swedish
           en:
             type: string
-            description: Keyword in English
+            description: Keyword set name in English
       origin_id:
         type: string
         description: "Set identifier in the originating system, if any"


### PR DESCRIPTION
Fixed issues where "keywordList" fetch failed due to wrong types. 
Ex. expected object, string was sent.
Also added new field "accessible"